### PR TITLE
Use Drill metadata to map returned data to Pandas dtypes

### DIFF
--- a/pydrill/client/__init__.py
+++ b/pydrill/client/__init__.py
@@ -15,15 +15,14 @@ class PyDrill(object):
     """
     # TODO: create better docs.
 
-    def __init__(self, host=os.environ.get('PYDRILL_HOST', 'localhost'), port=os.environ.get('PYDRILL_PORT', 8047),
-                 trasport_class=Transport, connection_class=RequestsHttpConnection, auth=None, **kwargs):
+    def __init__(self, host=os.environ.get('PYDRILL_HOST', 'localhost'), port=os.environ.get('PYDRILL_PORT', 8047), trasport_class=Transport, connection_class=RequestsHttpConnection, auth=None, **kwargs):
 
         self.transport = trasport_class(host, port, connection_class=connection_class, auth=auth, **kwargs)
 
     def perform_request(self, method, url, params=None, body=None):
         return self.transport.perform_request(method, url, params, body)
 
-    def is_active(self, timeout=2):
+    def is_active(self, timeout=2) -> bool:
         """
         :param timeout: int
         :return: boolean
@@ -40,7 +39,7 @@ class PyDrill(object):
 
         return False
 
-    def query(self, sql, timeout=10):
+    def query(self, sql, timeout=10) -> ResultQuery:
         """
         Submit a query and return results.
 
@@ -65,7 +64,7 @@ class PyDrill(object):
 
         return result
 
-    def plan(self, sql, timeout=10):
+    def plan(self, sql, timeout=10) -> ResultQuery:
         """
         :param sql: string
         :param timeout: int
@@ -74,7 +73,7 @@ class PyDrill(object):
         sql = 'explain plan for ' + sql
         return self.query(sql, timeout)
 
-    def stats(self, timeout=10):
+    def stats(self, timeout=10) -> Stats:
         """
         Get Drillbit information, such as ports numbers.
 
@@ -90,7 +89,7 @@ class PyDrill(object):
         }))
         return result
 
-    def metrics(self, timeout=10):
+    def metrics(self, timeout=10) -> Result:
         """
         Get the current memory metrics.
 
@@ -106,7 +105,7 @@ class PyDrill(object):
         }))
         return result
 
-    def threads(self, timeout=10):
+    def threads(self, timeout=10) -> Result:
         """
         Get the status of threads.
 
@@ -122,7 +121,7 @@ class PyDrill(object):
         }))
         return result
 
-    def options(self, timeout=10):
+    def options(self, timeout=10) -> Result:
         """
         List the name, default, and data type of the system and session options.
 
@@ -138,7 +137,7 @@ class PyDrill(object):
         }))
         return result
 
-    def storage(self, timeout=10):
+    def storage(self, timeout=10) -> Result:
         """
         Get the list of storage plugin names and configurations.
 
@@ -154,7 +153,7 @@ class PyDrill(object):
         }))
         return result
 
-    def storage_detail(self, name, timeout=10):
+    def storage_detail(self, name, timeout=10) -> Result:
         """
         Get the definition of the named storage plugin.
 
@@ -171,7 +170,7 @@ class PyDrill(object):
         }))
         return result
 
-    def storage_enable(self, name, value=True, timeout=10):
+    def storage_enable(self, name, value=True, timeout=10) -> Result:
         """
         Enable or disable the named storage plugin.
 
@@ -190,7 +189,7 @@ class PyDrill(object):
         }))
         return result
 
-    def storage_update(self, name, config, timeout=10):
+    def storage_update(self, name, config, timeout=10) -> Result:
         """
         Create or update a storage plugin configuration.
 
@@ -210,7 +209,7 @@ class PyDrill(object):
         }))
         return result
 
-    def storage_delete(self, name, timeout=10):
+    def storage_delete(self, name, timeout=10) -> Result:
         """
         Delete a storage plugin configuration.
 
@@ -227,7 +226,7 @@ class PyDrill(object):
         }))
         return result
 
-    def profiles(self, timeout=10):
+    def profiles(self, timeout=10) -> Result:
         """
         Get the profiles of running and completed queries.
 
@@ -243,7 +242,7 @@ class PyDrill(object):
         }))
         return result
 
-    def profile(self, query_id, timeout=10):
+    def profile(self, query_id, timeout=10) -> Result:
         """
         Get the profile of the query that has the given queryid.
 
@@ -260,7 +259,7 @@ class PyDrill(object):
         }))
         return result
 
-    def profile_cancel(self, query_id, timeout=10):
+    def profile_cancel(self, query_id, timeout=10) -> Result:
         """
         Cancel the query that has the given queryid.
 

--- a/pydrill/client/result.py
+++ b/pydrill/client/result.py
@@ -59,9 +59,9 @@ class ResultQuery(Result):
 
         if dtype:
             # the user has specified a single dtype for the entire dataframe
-            return pd.DataFrame.from_dict(self.rows, dtype=dtype)
+            return pd.DataFrame.from_dict(self.rows, dtype=dtype)[self.columns]
 
-        df = pd.DataFrame.from_dict(self.rows)
+        df = pd.DataFrame.from_dict(self.rows)[self.columns]
 
         # The columns in df all have a dtype of object because Drill's HTTP API
         # always quotes the values in the JSON it returns, thereby providing

--- a/pydrill/client/result.py
+++ b/pydrill/client/result.py
@@ -52,9 +52,12 @@ class ResultQuery(Result):
         for row in self.rows:
             yield row
 
-    def to_dataframe(self, dtype=None, convert_dtypes=False):
+    def to_dataframe(self, dtype=None, convert_dtypes=False) -> pd.DataFrame:
         if not PANDAS_AVAILABLE:
             raise ImproperlyConfigured("Please install pandas to use ResultQuery.to_dataframe().")
+
+        if len(self.rows) == 0:
+            return pd.DataFrame(columns=self.columns)
 
         if dtype:
             # the user has specified a single dtype for the entire dataframe

--- a/pydrill/client/result.py
+++ b/pydrill/client/result.py
@@ -14,7 +14,7 @@ except ImportError:
 DRILL_PANDAS_TYPE_MAP = {
         'BIGINT': 'Int64',
         'BINARY': 'object',
-        'BIT':  'boolean',
+        'BIT':  'bool',
         'DATE': 'datetime64[ns]',
         'FLOAT4': 'float32',
         'FLOAT8': 'float64',
@@ -67,21 +67,33 @@ class ResultQuery(Result):
         # DataFrame.from_dict(...) with a dict of strings.  We now use the
         # metadata returned by Drill to correct this
         for i in range(len(self.columns)):
+            col_name = self.columns[i]
             # strip any precision information that might be in the metdata e.g. VARCHAR(10)
-            m = re.sub(r'\(.*\)', '', self.metadata[i])
+            col_drill_type = re.sub(r'\(.*\)', '', self.metadata[i])
 
-            if m in DRILL_PANDAS_TYPE_MAP:
-                logger.debug("Mapping column {} of type {} to dtype {}".format(self.columns[i], self.metadata[i], DRILL_PANDAS_TYPE_MAP[m]))
-                if m == 'BIT':
-                    df[self.columns[i]] = df[self.columns[i]] == 'true'
-                elif m == 'TIME': # m in ['TIME', 'INTERVAL']: # parsing of ISO-8601 intervals appears broken as of Pandas 1.0.3
-                    df[self.columns[i]] = pd.to_timedelta(df[self.columns[i]])
-                elif m in ['BIGINT', 'FLOAT4', 'FLOAT8', 'INT', 'SMALLINT']:
-                    df[self.columns[i]] = pd.to_numeric(df[self.columns[i]])
-
-                df[self.columns[i]] = df[self.columns[i]].astype(DRILL_PANDAS_TYPE_MAP[m])
+            if col_drill_type not in DRILL_PANDAS_TYPE_MAP:
+                logger.warn('No known mapping of Drill column {} of type {} to a Pandas dtype'.format(col_name, m))
             else:
-                logger.warn("Could not map Drill column {} of type {} to a Pandas dtype".format(self.columns[i], m))
+                col_dtype = DRILL_PANDAS_TYPE_MAP[col_drill_type]
+                logger.debug('Mapping column {} of Drill type {} to dtype {}'.format(col_name, col_drill_type, col_dtype))
+
+                # Pandas < 1.0.0 cannot handle null ints so we sometimes cannot cast to an int dtype
+                can_cast = True
+
+                if col_name == 'BIT':
+                    df[col_name] = df[col_name] == 'true'
+                elif col_name == 'TIME': # col_name in ['TIME', 'INTERVAL']: # parsing of ISO-8601 intervals appears broken as of Pandas 1.0.3
+                    df[col_name] = pd.to_timedelta(df[col_name])
+                elif col_name in ['FLOAT4', 'FLOAT8']:
+                    df[col_name] = pd.to_numeric(df[col_name])
+                elif col_name in ['BIGINT', 'INT', 'SMALLINT']:
+                    df[col_name] = pd.to_numeric(df[col_name])
+                    if pd.__version__ < '1' and df[col_name].isnull().values.any():
+                        logger.warn('Column {} of Drill type {} contains nulls so cannot be converted to an integer dtype in Pandas < 1.0.0'.format(col_name, col_drill_type))
+                        can_cast = False
+
+                if can_cast:
+                    df[col_name] = df[col_name].astype(col_dtype)
 
         return df
 

--- a/pydrill/client/result.py
+++ b/pydrill/client/result.py
@@ -52,7 +52,7 @@ class ResultQuery(Result):
         for row in self.rows:
             yield row
 
-    def to_dataframe(self, dtype=None):
+    def to_dataframe(self, dtype=None, convert_dtypes=False):
         if not PANDAS_AVAILABLE:
             raise ImproperlyConfigured("Please install pandas to use ResultQuery.to_dataframe().")
 
@@ -61,6 +61,8 @@ class ResultQuery(Result):
             return pd.DataFrame.from_dict(self.rows, dtype=dtype)[self.columns]
 
         df = pd.DataFrame.from_dict(self.rows)[self.columns]
+
+        if not convert_dtypes: return df
 
         # The columns in df all have a dtype of object because Drill's HTTP API
         # always quotes the values in the JSON it returns, thereby providing

--- a/pydrill/client/result.py
+++ b/pydrill/client/result.py
@@ -90,7 +90,8 @@ class ResultQuery(Result):
                 elif col_drill_type == 'TIME': # col_name in ['TIME', 'INTERVAL']: # parsing of ISO-8601 intervals appears broken as of Pandas 1.0.3
                     df[col_name] = pd.to_timedelta(df[col_name])
                 elif col_drill_type in ['FLOAT4', 'FLOAT8']:
-                    df[col_name] = pd.to_numeric(df[col_name])
+                    # coerce errors when float parsing to handle the case when Drill returns 'NaN'
+                    df[col_name] = pd.to_numeric(df[col_name], errors='coerce')
                 elif col_drill_type in ['BIGINT', 'INT', 'SMALLINT']:
                     df[col_name] = pd.to_numeric(df[col_name])
                     if pd.__version__ < '1' and df[col_name].isnull().values.any():

--- a/pydrill/client/result.py
+++ b/pydrill/client/result.py
@@ -12,17 +12,17 @@ except ImportError:
     PANDAS_AVAILABLE = False
 
 DRILL_PANDAS_TYPE_MAP = {
-        'BIGINT': 'int64',
+        'BIGINT': 'Int64',
         'BINARY': 'object',
-        'BIT':  'boolean', # handled as a special case
+        'BIT':  'boolean',
         'DATE': 'datetime64[ns]',
         'FLOAT4': 'float32',
         'FLOAT8': 'float64',
-        'INT': 'int32',
+        'INT': 'Int32',
         'INTERVALDAY': 'string' if pd.__version__ >= '1' else 'object',
         'INTERVALYEAR': 'string' if pd.__version__ >= '1' else 'object',
-        'SMALLINT': 'int32',
-        'TIME': 'timedelta64[ns]', # handled as a special case
+        'SMALLINT': 'Int32',
+        'TIME': 'timedelta64[ns]',
         'TIMESTAMP': 'datetime64[ns]',
         'VARDECIMAL': 'object',
         'VARCHAR' : 'string' if pd.__version__ >= '1' else 'object'
@@ -38,7 +38,7 @@ class Result(object):
 
 class ResultQuery(Result):
     """
-    Class responsible for maintaining a information returned from Drill.
+    Class responsible for maintaining information returned from Drill.
 
     It is iterable.
     """
@@ -76,8 +76,10 @@ class ResultQuery(Result):
                     df[self.columns[i]] = df[self.columns[i]] == 'true'
                 elif m == 'TIME': # m in ['TIME', 'INTERVAL']: # parsing of ISO-8601 intervals appears broken as of Pandas 1.0.3
                     df[self.columns[i]] = pd.to_timedelta(df[self.columns[i]])
-                else:
-                    df[self.columns[i]] = df[self.columns[i]].astype(DRILL_PANDAS_TYPE_MAP[m])
+                elif m in ['BIGINT', 'FLOAT4', 'FLOAT8', 'INT', 'SMALLINT']:
+                    df[self.columns[i]] = pd.to_numeric(df[self.columns[i]])
+
+                df[self.columns[i]] = df[self.columns[i]].astype(DRILL_PANDAS_TYPE_MAP[m])
             else:
                 logger.warn("Could not map Drill column {} of type {} to a Pandas dtype".format(self.columns[i], m))
 

--- a/pydrill/client/result.py
+++ b/pydrill/client/result.py
@@ -82,13 +82,13 @@ class ResultQuery(Result):
                 # Pandas < 1.0.0 cannot handle null ints so we sometimes cannot cast to an int dtype
                 can_cast = True
 
-                if col_name == 'BIT':
+                if col_drill_type == 'BIT':
                     df[col_name] = df[col_name] == 'true'
-                elif col_name == 'TIME': # col_name in ['TIME', 'INTERVAL']: # parsing of ISO-8601 intervals appears broken as of Pandas 1.0.3
+                elif col_drill_type == 'TIME': # col_name in ['TIME', 'INTERVAL']: # parsing of ISO-8601 intervals appears broken as of Pandas 1.0.3
                     df[col_name] = pd.to_timedelta(df[col_name])
-                elif col_name in ['FLOAT4', 'FLOAT8']:
+                elif col_drill_type in ['FLOAT4', 'FLOAT8']:
                     df[col_name] = pd.to_numeric(df[col_name])
-                elif col_name in ['BIGINT', 'INT', 'SMALLINT']:
+                elif col_drill_type in ['BIGINT', 'INT', 'SMALLINT']:
                     df[col_name] = pd.to_numeric(df[col_name])
                     if pd.__version__ < '1' and df[col_name].isnull().values.any():
                         logger.warn('Column {} of Drill type {} contains nulls so cannot be converted to an integer dtype in Pandas < 1.0.0'.format(col_name, col_drill_type))

--- a/pydrill/transport.py
+++ b/pydrill/transport.py
@@ -12,9 +12,20 @@ class Transport(object):
     Main interface is the `perform_request` method.
     """
 
-    def __init__(self, host, port, connection_class, serializers=None, default_mimetype='application/json',
-                 max_retries=3, retry_on_status=(503, 504,), serializer=JSONSerializer(), deserializer=Deserializer(),
-                 retry_on_timeout=False, send_get_body_as='GET', **kwargs):
+    def __init__(self,
+            host,
+            port,
+            connection_class,
+            serializers=None,
+            default_mimetype='application/json',
+            max_retries=3,
+            retry_on_status=(503, 504,),
+            serializer=JSONSerializer(),
+            deserializer=Deserializer(),
+            retry_on_timeout=False,
+            send_get_body_as='GET',
+            **kwargs):
+
         self.deserializer = deserializer
         self.port = port
         self.host = host


### PR DESCRIPTION
Data fetched using the Drill HTTP API are always handled as strings.  This PR uses the metadata returned in the Drill HTTP response to map the returned data to Pandas dtypes as best it can.

### Results:
```
drill.query("""
select 
  current_date `date`,
  current_time `time`,
  current_timestamp `timestamp`,
  1=1 as `boolean`,
  'foobar' as `varchar`,
  cast(2 as int) `int`,
  cast(2 as bigint) `bigint`,
  cast(2 as float) `float`,
  cast(2 as double) `double`,
  interval '2' day `interval`
""").to_dataframe().info()

<class 'pandas.core.frame.DataFrame'>
RangeIndex: 1 entries, 0 to 0
Data columns (total 10 columns):
 #   Column     Non-Null Count  Dtype          
---  ------     --------------  -----          
 0   date       1 non-null      datetime64[ns] 
 1   boolean    1 non-null      bool           
 2   double     1 non-null      float64        
 3   varchar    1 non-null      string         
 4   interval   1 non-null      object         
 5   time       1 non-null      timedelta64[ns]
 6   float      1 non-null      float32        
 7   bigint     1 non-null      int64          
 8   int        1 non-null      int32          
 9   timestamp  1 non-null      datetime64[ns] 
dtypes: bool(1), datetime64[ns](2), float32(1), float64(1), int32(1), int64(1), object(1), string(1), timedelta64[ns](1)
```